### PR TITLE
LFR-510 fix empty email with attachment issue

### DIFF
--- a/lib/griddler/amazon_s3_ses/adapter.rb
+++ b/lib/griddler/amazon_s3_ses/adapter.rb
@@ -87,7 +87,7 @@ module Griddler
       end
 
       def text_part
-        force_body_to_utf_8_string(multipart? ? message.text_part.body : message.body)
+        force_body_to_utf_8_string(multipart? ? message.text_part.try(:body) : message.try(:body))
       end
 
       def html_part


### PR DESCRIPTION
When an email had attachments, but no text, it would fail